### PR TITLE
fixes #5 - use javax.inject in main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,6 @@
       <artifactId>camel-core</artifactId>
       <version>2.15.2</version>
     </dependency>
-    <dependency>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-guice</artifactId>
-        <version>2.15.2</version>
-        <!-- use the same version as your Camel core version -->
-    </dependency>
     
     <!-- support camel documentation -->
     <dependency>
@@ -46,6 +40,18 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.12</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.0</version>
     </dependency>
 
     <!-- testing -->
@@ -75,6 +81,14 @@
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.12</version>
       <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-guice</artifactId>
+      <version>2.15.2</version>
+      <scope>test</scope>
+      <!-- use the same version as your Camel core version -->
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/redhat/lightblue/camel/LightblueComponent.java
+++ b/src/main/java/com/redhat/lightblue/camel/LightblueComponent.java
@@ -2,11 +2,13 @@ package com.redhat.lightblue.camel;
 
 import java.util.Map;
 
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.impl.UriEndpointComponent;
 
-import com.google.inject.Inject;
 import com.redhat.lightblue.client.LightblueClient;
 import com.redhat.lightblue.client.request.LightblueRequest;
 
@@ -15,9 +17,7 @@ import com.redhat.lightblue.client.request.LightblueRequest;
  */
 public class LightblueComponent extends UriEndpointComponent {
 
-    @Inject
     private LightblueClient lightblueClient;
-    @Inject(optional=true)
     private LightblueRequest lightbluePollingRequest;
 
     public LightblueComponent() {
@@ -40,13 +40,14 @@ public class LightblueComponent extends UriEndpointComponent {
         return endpoint;
     }
 
+    @Inject
     public void setLightblueClient(LightblueClient lightblueClient) {
         this.lightblueClient = lightblueClient;
     }
 
-    public void setLightbluePollingRequest(LightblueRequest lightbluePollingRequest) {
+    @Inject
+    public void setLightbluePollingRequest(@Nullable LightblueRequest lightbluePollingRequest) {
         this.lightbluePollingRequest = lightbluePollingRequest;
     }
-
 
 }

--- a/src/test/java/com/redhat/lightblue/camel/TestCamelModule.java
+++ b/src/test/java/com/redhat/lightblue/camel/TestCamelModule.java
@@ -7,6 +7,7 @@ import org.apache.camel.RoutesBuilder;
 import org.apache.camel.guice.CamelModule;
 
 import com.google.inject.Injector;
+import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.redhat.lightblue.client.LightblueClient;
 import com.redhat.lightblue.client.request.LightblueRequest;
@@ -17,8 +18,7 @@ public class TestCamelModule extends CamelModule {
     private final LightblueRequest request;
 
     public TestCamelModule(LightblueClient client) {
-        this.client = client;
-        this.request = null;
+        this(client, null);
     }
 
     public TestCamelModule(LightblueClient client, LightblueRequest request) {
@@ -32,9 +32,14 @@ public class TestCamelModule extends CamelModule {
         super.configure();
 
         bind(LightblueClient.class).toInstance(client);
-        if (request != null)
-            bind(LightblueRequest.class).toInstance(request);
+        bind(LightblueRequest.class).toProvider(new Provider<LightblueRequest>() {
 
+            @Override
+            public LightblueRequest get() {
+                return request;
+            }
+
+        });
     }
 
     @Provides


### PR DESCRIPTION
Uses guice only for test so that other DI frameworks could be used if desired by end users.
