### PR TITLE
Lightblue endpoints should fail gracefully when Lightblue does not return a response

### DIFF
--- a/src/main/java/com/redhat/lightblue/camel/LightblueProducer.java
+++ b/src/main/java/com/redhat/lightblue/camel/LightblueProducer.java
@@ -32,9 +32,10 @@ public class LightblueProducer extends DefaultProducer {
             Object response = sendRequest(req);
             exchange.getIn().setBody(response);
         } catch (LightblueException e) {
-            exchange.getIn().setBody(e.getLightblueResponse());
+            exchange.getIn().setBody(e.getLightblueResponse() == null ? e.getCause(): e.getLightblueResponse().getText());
             exchange.setException(e);
         } catch (Exception e) {
+            exchange.getIn().setBody(e.getMessage());
             exchange.setException(
                     new Exception("Unexpected exception", e));
         }

--- a/src/main/java/com/redhat/lightblue/camel/LightblueScheduledPollConsumer.java
+++ b/src/main/java/com/redhat/lightblue/camel/LightblueScheduledPollConsumer.java
@@ -31,7 +31,7 @@ public class LightblueScheduledPollConsumer extends ScheduledPollConsumer {
             }
             exchange.getIn().setBody(response);
         } catch (LightblueException e) {
-            exchange.getIn().setBody(e.getLightblueResponse());
+            exchange.getIn().setBody(e.getLightblueResponse() == null ? e.getCause(): e.getLightblueResponse().getText());
             exchange.setException(e);
         } catch (Exception e) {
             exchange.setException(

--- a/src/test/java/com/redhat/lightblue/camel/ConsumerNoLightblueResponseTest.java
+++ b/src/test/java/com/redhat/lightblue/camel/ConsumerNoLightblueResponseTest.java
@@ -1,0 +1,44 @@
+package com.redhat.lightblue.camel;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Test for {@link SampleConsumerRoute}.
+ *
+ * @author mpatercz
+ *
+ */
+public class ConsumerNoLightblueResponseTest extends AbstractConsumerTest {
+
+    public ConsumerNoLightblueResponseTest() throws Exception {
+        super();
+    }
+
+    @Override
+    public JsonNode[] getMetadataJsonNodes() throws Exception {
+        return new JsonNode[]{/* Nothing! */};
+    }
+
+    @Test
+    public void testMessageFromLightblue() throws Exception {
+        stopHttpServer();
+
+        //Setup asserts
+        eventResultEndpoint.expectedMessageCount(0);
+
+        userResultEndpoint.expectedMessageCount(0);
+
+        // SampleConsumerRoute is consuming from 2 endpoints
+        exceptionEndpoint.expectedMessageCount(2);
+        exceptionEndpoint.expectedBodiesReceivedInAnyOrder("java.net.ConnectException: Connection refused",
+                "java.net.ConnectException: Connection refused");
+
+        //Verify asserts
+        eventResultEndpoint.assertIsSatisfied();
+        userResultEndpoint.assertIsSatisfied();
+        exceptionEndpoint.assertIsSatisfied();
+    }
+
+}

--- a/src/test/java/com/redhat/lightblue/camel/ProducerNoLightblueResponseTest.java
+++ b/src/test/java/com/redhat/lightblue/camel/ProducerNoLightblueResponseTest.java
@@ -1,0 +1,50 @@
+package com.redhat.lightblue.camel;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+
+/**
+ * Test for {@link SampleProducerRoute}.
+ *
+ * @author mpatercz
+ *
+ */
+public class ProducerNoLightblueResponseTest extends AbstractProducerTest {
+
+    public ProducerNoLightblueResponseTest() throws Exception {
+        super();
+    }
+
+    @Override
+    public JsonNode[] getMetadataJsonNodes() throws Exception {
+        return new JsonNode[] {};
+    }
+
+    @Before
+    public void stopLightblue() {
+        stopHttpServer();
+    }
+
+    @Test
+    public void testLightblueFailure() throws Exception {
+        //setup asserts
+        resultEndpoint.expectedMessageCount(0);
+
+        exceptionEndpoint.expectedMessageCount(1);
+        exceptionEndpoint.expectedBodiesReceived("java.net.ConnectException: Connection refused");
+
+        //Run test
+        String message = Resources.toString(Resources.getResource("./data/user-message.xml"), Charsets.UTF_8);
+        template.sendBody(message);
+
+        //Verify asserts
+        resultEndpoint.assertIsSatisfied();
+        exceptionEndpoint.assertIsSatisfied();
+
+    }
+
+}

--- a/src/test/java/com/redhat/lightblue/camel/SampleConsumerRoute.java
+++ b/src/test/java/com/redhat/lightblue/camel/SampleConsumerRoute.java
@@ -13,7 +13,7 @@ public class SampleConsumerRoute extends RouteBuilder {
     public void configure() throws Exception {
 
         onException(LightblueException.class)
-            .transform(simple("${body.getText}"))
+            .transform(simple("${body.toString()}"))
             .to("mock:exception")
             .handled(true);
 

--- a/src/test/java/com/redhat/lightblue/camel/SampleProducerRoute.java
+++ b/src/test/java/com/redhat/lightblue/camel/SampleProducerRoute.java
@@ -5,15 +5,14 @@ import org.apache.camel.builder.RouteBuilder;
 import com.redhat.lightblue.camel.model.User;
 import com.redhat.lightblue.camel.request.LightblueInsertRequestFactory;
 import com.redhat.lightblue.camel.utils.JacksonXmlDataFormat;
-import com.redhat.lightblue.client.response.LightblueException;
 
 public class SampleProducerRoute extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
 
-        onException(LightblueException.class)
-            .transform(simple("${body.getText}"))
+        onException(Exception.class)
+            .transform(simple("${body.toString()}"))
             .to("mock:exception")
             .handled(true);
 


### PR DESCRIPTION
There are cases when lightblue does not return anything at all or it returns html instead of json (e.g. system error). The endpoints should fail gracefully no matter what is the underlying exception.
