### PR TITLE
Don't try to lock duplicates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,14 @@
       <!-- use the same version as your Camel core version -->
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
+
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Duplicates are events with the same resourceId. This change is to avoid threads making multiple lock acquire attempts for the same resourceId which is already taken. 
